### PR TITLE
Make sure to set the distorted_image to all zeros to start with.

### DIFF
--- a/image_geometry/test/utest.cpp
+++ b/image_geometry/test/utest.cpp
@@ -193,7 +193,7 @@ TEST_F(PinholeTest, rectifyIfCalibrated)
   // the test again.
   // Then zero out all the distortion coefficients and test
   // that the output image is the same as the input.
-  cv::Mat distorted_image(cv::Size(cam_info_.width, cam_info_.height), CV_8UC3);
+  cv::Mat distorted_image(cv::Size(cam_info_.width, cam_info_.height), CV_8UC3, cv::Scalar(0, 0, 0));
 
   // draw a grid
   const cv::Scalar color = cv::Scalar(255, 255, 255);


### PR DESCRIPTION
This avoids a valgrind error.

This is also a problem in upstream vision_opencv, so I've opened a PR there as well: ros-perception/vision_opencv#166

CI:
windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2656)](http://ci.ros2.org/job/ci_windows/2656/)
linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2548)](http://ci.ros2.org/job/ci_linux/2548/)
linux aarch64: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=145)](http://ci.ros2.org/job/ci_linux-aarch64/145/)
osx: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2012)](http://ci.ros2.org/job/ci_osx/2012/)