### PR TITLE
remove dependency on boost given that we dont use it anymore

### DIFF
--- a/image_geometry/CMakeLists.txt
+++ b/image_geometry/CMakeLists.txt
@@ -9,7 +9,6 @@ endif()
 
 find_package(OpenCV REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(Boost REQUIRED)
 
 include_directories(include
                     ${OpenCV_INCLUDE_DIRS}

--- a/image_geometry/package.xml
+++ b/image_geometry/package.xml
@@ -22,8 +22,6 @@
   <depend>opencv3</depend>
   <depend>sensor_msgs</depend>
 
-  <build_depend>boost</build_depend>
-
   <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
 


### PR DESCRIPTION
follow up of https://github.com/ros2/vision_opencv/pull/1#discussion_r113727909.
With that change we can compile ros2 using only the deps listed on the install page [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2559)](http://ci.ros2.org/job/ci_linux/2559/)