### PR TITLE
Use upstream opencv2.

### DIFF
--- a/image_geometry/package.xml
+++ b/image_geometry/package.xml
@@ -19,7 +19,7 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <depend>opencv3</depend>
+  <depend>libopencv-dev</depend>
   <depend>sensor_msgs</depend>
 
   <test_depend>ament_cmake_nose</test_depend>


### PR DESCRIPTION
As discussed in Slack, despite this dependency key, ROS 2 actually builds
against upstream opencv (2.x) rather than opencv3.