### PR TITLE
Comment out unported test

### DIFF
--- a/image_geometry/test/CMakeLists.txt
+++ b/image_geometry/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(ament_cmake_gtest REQUIRED)
 find_package(ament_cmake_pytest REQUIRED)
 
-ament_add_pytest_test(directed.py .)
+ament_add_pytest_test(directed.py "directed.py")
 
 ament_add_gtest(${PROJECT_NAME}-utest utest.cpp APPEND_LIBRARY_DIRS "${image_geometry_lib_dir}")
 target_link_libraries(${PROJECT_NAME}-utest ${PROJECT_NAME} ${OpenCV_LIBS})

--- a/image_geometry/test/CMakeLists.txt
+++ b/image_geometry/test/CMakeLists.txt
@@ -1,7 +1,8 @@
 find_package(ament_cmake_gtest REQUIRED)
-find_package(ament_cmake_pytest REQUIRED)
+# TODO(clalancette) Reenable this when tests are ported to ROS 2
+# find_package(ament_cmake_pytest REQUIRED)
 
-ament_add_pytest_test(directed.py "directed.py")
+# ament_add_pytest_test(directed.py "directed.py")
 
 ament_add_gtest(${PROJECT_NAME}-utest utest.cpp APPEND_LIBRARY_DIRS "${image_geometry_lib_dir}")
 target_link_libraries(${PROJECT_NAME}-utest ${PROJECT_NAME} ${OpenCV_LIBS})

--- a/image_geometry/test/CMakeLists.txt
+++ b/image_geometry/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(ament_cmake_gtest REQUIRED)
-# TODO(clalancette) Reenable this when tests are ported to ROS 2
+# TODO(mikaelarguedas) Reenable this when tests are ported to ROS 2
 # find_package(ament_cmake_pytest REQUIRED)
 
 # ament_add_pytest_test(directed.py "directed.py")


### PR DESCRIPTION
This test was never ran with nose but nose was not complaining about running 0 tests while pytest does.

The first commit update the CMake to be able to actually run the test.
The second commit comments out the test as it has not been ported to ROS2 and our machines don;t have openCV with python bindings to test it once the test is updated.

I submitted a PR upstream to make the test python3 compatible https://github.com/ros-perception/vision_opencv/pull/189